### PR TITLE
Fix rn.socket.DialTimeout undefined error

### DIFF
--- a/networking.go
+++ b/networking.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/anacrolix/utp"
 	"github.com/ccding/go-stun/stun"
@@ -151,7 +150,7 @@ func (rn *realNetworking) sendMessage(msg *message, expectResponse bool, id int6
 	msg.ID = id
 	rn.mutex.Unlock()
 
-	conn, err := rn.socket.DialTimeout("["+msg.Receiver.IP.String()+"]:"+strconv.Itoa(msg.Receiver.Port), time.Second)
+	conn, err := rn.socket.Dial("[" + msg.Receiver.IP.String() + "]:" + strconv.Itoa(msg.Receiver.Port))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Networking library seems to have changed. The following error was appearing and preventing the project from building.

`networking.go:154:24: rn.socket.DialTimeout undefined (type *utp.Socket has no field or method DialTimeout)`

Note: This change removes the timeout (1 second) from the Dial() call.